### PR TITLE
ci: add GitHub Actions workflow for lint and build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs on every push to `main` and on pull requests targeting `main`.

### Workflow steps:
1. **Checkout** — uses `actions/checkout@v4`
2. **Setup Node.js** — Node 22 with npm cache
3. **Install dependencies** — `npm ci` for deterministic installs
4. **Lint** — `npm run lint` (eslint with Next.js config)
5. **Build** — `npm run build` (Next.js production build)

### Why
This repo had no CI pipeline. Automated lint and build checks prevent broken code from landing on `main`.

---
*Generated by [nightshift](https://github.com/Microck/hermes-nightshift-glm) • task: ci-fixes*